### PR TITLE
if no arguments given, default to -c (search for runcc config)

### DIFF
--- a/runcc/src/cli/options.rs
+++ b/runcc/src/cli/options.rs
@@ -8,9 +8,6 @@ use crate::{read, KillBehavior, RunConfig};
 /// Run commands concurrently
 #[derive(Parser)]
 #[clap(version, author, bin_name = "cargo runcc")]
-#[clap(
-    setting = AppSettings::ArgRequiredElseHelp,
-)]
 pub struct Opts {
     /// Commands to run concurrently
     command: Vec<String>,
@@ -77,6 +74,14 @@ impl Opts {
             Some(envs)
         } else {
             None
+        };
+
+        // if no commands and no config are given, act as if -c was passed, i.e.
+        // default to searching for the default runcc.* file in the local
+        // directory
+        let (commands, config) = match (&commands[..], &config) {
+            ([], None) => (Vec::new(), Some(None)),
+            _ => (commands, config),
         };
 
         if commands.len() > 0 {

--- a/runcc/tests/cmd/help.trycmd
+++ b/runcc/tests/cmd/help.trycmd
@@ -4,24 +4,8 @@ cargo runcc
 
 ```trycmd
 $ cargo-runcc
-? 2
-cargo-runcc 2.0.2
-Equal Ma <equalma@outlook.com>
-Run commands concurrently
-
-USAGE:
-    cargo runcc [OPTIONS] [COMMAND]...
-
-ARGS:
-    <COMMAND>...    Commands to run concurrently
-
-OPTIONS:
-    -c, --config <CONFIG>                        Config file path
-    -e, --env <ENV>                              Specify env vars with K=V
-    -h, --help                                   Print help information
-    -k, --kill <KILL>                            What to do after some command exits
-        --max-label-length <MAX_LABEL_LENGTH>    Max length to print label in logs
-    -V, --version                                Print version information
+? 1
+Error: Config file error: No files in "current working directory" matched the patterns: runcc.json, runcc.yml, runcc.yaml, runcc.ron, runcc.toml, Cargo.toml
 
 ```
 


### PR DESCRIPTION
Hello! This is a really useful program, I like it a lot!

One thing I don't understand is to why require `-c` to use the default config file? Invoking runcc with no commands does not make sense, wouldn't it be better to simply assume we want the config file in this case?

This MR implements that.